### PR TITLE
Set zygote process priority to -20 to speed up VM startup time.

### DIFF
--- a/rootdir/init.zygote32.rc
+++ b/rootdir/init.zygote32.rc
@@ -1,5 +1,6 @@
 service zygote /system/bin/app_process -Xzygote /system/bin --zygote --start-system-server
     class main
+    priority -20
     socket zygote stream 660 root system
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on

--- a/rootdir/init.zygote32_64.rc
+++ b/rootdir/init.zygote32_64.rc
@@ -1,5 +1,6 @@
 service zygote /system/bin/app_process32 -Xzygote /system/bin --zygote --start-system-server --socket-name=zygote
     class main
+    priority -20
     socket zygote stream 660 root system
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on
@@ -11,6 +12,7 @@ service zygote /system/bin/app_process32 -Xzygote /system/bin --zygote --start-s
 
 service zygote_secondary /system/bin/app_process64 -Xzygote /system/bin --zygote --socket-name=zygote_secondary
     class main
+    priority -20
     socket zygote_secondary stream 660 root system
     onrestart restart zygote
     writepid /dev/cpuset/foreground/tasks

--- a/rootdir/init.zygote64.rc
+++ b/rootdir/init.zygote64.rc
@@ -1,5 +1,6 @@
 service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-system-server
     class main
+    priority -20
     socket zygote stream 660 root system
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on

--- a/rootdir/init.zygote64_32.rc
+++ b/rootdir/init.zygote64_32.rc
@@ -1,5 +1,6 @@
 service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-system-server --socket-name=zygote
     class main
+    priority -20
     socket zygote stream 660 root system
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on
@@ -11,6 +12,7 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
 
 service zygote_secondary /system/bin/app_process32 -Xzygote /system/bin --zygote --socket-name=zygote_secondary
     class main
+    priority -20
     socket zygote_secondary stream 660 root system
     onrestart restart zygote
     writepid /dev/cpuset/foreground/tasks


### PR DESCRIPTION
Tests for Nexus9 device shows 450ms boot time speedup, 180ms for Nexus
5X.

Bug: 28866384

Change-Id: Icefd130d4bfe5538dae5b9518250807351b0789e
Signed-off-by: CheckYourScreen <nimitmehta95@gmail.com>